### PR TITLE
Add documentation for `PROXY_URL` environment variable

### DIFF
--- a/docs/self-hosting/environment-variables/basic.mdx
+++ b/docs/self-hosting/environment-variables/basic.mdx
@@ -80,6 +80,17 @@ Further reading:
 
 For specific content, please refer to the [Feature Flags](/docs/self-hosting/advanced/feature-flags) documentation.
 
+### `PROXY_URL`
+
+- Type: Optional
+- Description: Used to specify the proxy URL for connecting to external services. The value of this variable should be different in different deployment environments.
+- Default: -
+- Example: `http://127.0.0.1:7890` or `socks5://localhost:7891`
+
+<Callout type="info">
+If you're using Docker Desktop on Windows or macOS, it relies on a virtual machine. In this setup, `localhost` / `127.0.0.1` refers to the localhost of the container itself. In such cases, please try using `host.docker.internal` instead of `localhost`.
+</Callout>
+
 ## Plugin Service
 
 ### `PLUGINS_INDEX_URL`

--- a/docs/self-hosting/environment-variables/basic.zh-CN.mdx
+++ b/docs/self-hosting/environment-variables/basic.zh-CN.mdx
@@ -76,6 +76,18 @@ LobeChat 在部署时提供了一些额外的配置项，你可以使用环境�
 
 具体的内容可以参见 [特性标志](/zh/docs/self-hosting/advanced/feature-flags) 中的说明。
 
+### `PROXY_URL`
+
+- 类型：可选
+- 描述：用于指定连接到外部服务的代理 URL。该变量的值在不同的部署环境中应该有所不同。
+- 默认值：-
+- 示例：`http://127.0.0.1:7890` 或 `socks5://localhost:7891`
+
+
+<Callout type="info">
+`Docker Desktop` 在 `Windows `和 `macOS `上走的是虚拟机方案，如果是 `localhost` / `127.0.0.1` 是走到自身容器的 `localhost`，此时请尝试用 `host.docker.internal` 替代 `localhost`
+</Callout>
+
 ## 插件服务
 
 ### `PLUGINS_INDEX_URL`


### PR DESCRIPTION
Related to [#3362](https://github.com/lobehub/lobe-chat/pull/3362)

Add documentation for `PROXY_URL` environment variable in both English and Chinese versions of the environment variables guide.

* **English Documentation**
  - Add `PROXY_URL` section to specify the proxy URL for connecting to external services.
  - Include example values and a callout for Docker Desktop users.

* **Chinese Documentation**
  - Add `PROXY_URL` section to specify the proxy URL for connecting to external services.
  - Include example values and a callout for Docker Desktop users.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/lobehub/lobe-chat/pull/3362?shareId=55b970c4-cc09-4d85-af42-c86f0aa4c582).