### PR TITLE
🔨 chore: add `buildCohereMessage` function to force use first user content

### DIFF
--- a/src/libs/agent-runtime/bedrock/index.ts
+++ b/src/libs/agent-runtime/bedrock/index.ts
@@ -8,7 +8,7 @@ import { LobeRuntimeAI } from '../BaseAI';
 import { AgentRuntimeErrorType } from '../error';
 import { ChatCompetitionOptions, ChatStreamPayload, ModelProvider } from '../types';
 import { buildAnthropicMessages, buildAnthropicTools } from '../utils/anthropicHelpers';
-import { buildCohereChatHistory } from '../utils/cohereHelpers';
+import { buildCohereChatHistory, buildCohereMessage } from '../utils/cohereHelpers';
 import { AgentRuntimeError } from '../utils/createError';
 import { debugStream } from '../utils/debugStream';
 import { StreamingResponse } from '../utils/response';
@@ -122,7 +122,7 @@ export class LobeBedrockAI implements LobeRuntimeAI {
         chat_history: buildCohereChatHistory(messages),
         frequency_penalty: frequency_penalty,
         max_tokens: max_tokens || 4096,
-        message: messages[0].content,
+        message: buildCohereMessage(messages),
         p: (top_p !== undefined && top_p > 0 && top_p < 1) ? top_p : undefined,
         presence_penalty: presence_penalty,
         temperature: temperature,

--- a/src/libs/agent-runtime/utils/cohereHelpers.ts
+++ b/src/libs/agent-runtime/utils/cohereHelpers.ts
@@ -1,4 +1,4 @@
-export const buildCohereChatHistory = (messages) => {
+export const buildCohereChatHistory = (messages: any[]) => {
   return messages.map(msg => {
     return {
       message: msg.content,
@@ -7,7 +7,7 @@ export const buildCohereChatHistory = (messages) => {
   });
 };
 
-export const buildCohereMessage = (messages) => {
+export const buildCohereMessage = (messages: any[]) => {
   const userMessage = messages.find(msg => msg.role === 'user');
   return userMessage ? userMessage.content : null;
 };

--- a/src/libs/agent-runtime/utils/cohereHelpers.ts
+++ b/src/libs/agent-runtime/utils/cohereHelpers.ts
@@ -6,3 +6,8 @@ export const buildCohereChatHistory = (messages) => {
     };
   });
 };
+
+export const buildCohereMessage = (messages) => {
+  const userMessage = messages.find(msg => msg.role === 'user');
+  return userMessage ? userMessage.content : null;
+};


### PR DESCRIPTION
#### 💻 变更类型 | Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔀 变更说明 | Description of Change

<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 📝 补充信息 | Additional Information

<!-- Add any other context about the Pull Request here. -->
